### PR TITLE
PKG-16175: xcb-util-image 0.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
     - pkg-config
   host:
     - libxcb {{ libxcb }}
-    - xorg-util-macros ==1.19.0
-    - xorg-xorgproto ==2024.1
+    - xcb-util
+    - xorg-xorgproto
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,14 +17,14 @@ build:
 
 requirements:
   build:
-    - {{ stdlib("c") }}
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - make
     - pkg-config
   host:
     - libxcb {{ libxcb }}
-    - xcb-util
-    - xorg-xorgproto
+    - xcb-util {{ xcb_util }}
+    - xorg-xorgproto {{ xorg_xorgproto }}
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,23 @@
 {% set name = "xcb-util-image" %}
-{% set version = "0.4.0" %}
+{% set version = "0.4.1" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://xcb.freedesktop.org/dist/xcb-util-image-{{ version }}.tar.bz2
-  sha256: 2db96a37d78831d643538dd1b595d7d712e04bdccf8896a5e18ce0f398ea2ffc
+  url: https://xcb.freedesktop.org/dist/{{ name }}-{{ version }}.tar.xz
+  sha256: ccad8ee5dadb1271fd4727ad14d9bd77a64e505608766c4e98267d9aede40d3d
 
 build:
-  number: 2
+  number: 0
   skip: true  # [not linux]
   run_exports:
     - {{ pin_subpackage('xcb-util-image', max_pin='x.x') }}
 
 requirements:
   build:
+    - {{ stdlib("c") }}
     - {{ compiler('c') }}
     - make
     - pkg-config

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,9 +22,9 @@ requirements:
     - make
     - pkg-config
   host:
-    - libxcb
-    - xcb-util
-    - xorg-xproto
+    - libxcb {{ libxcb }}
+    - xorg-util-macros ==1.19.0
+    - xorg-xorgproto ==2024.1
 
 test:
   commands:
@@ -38,6 +38,8 @@ about:
   license_family: MIT
   license_file: COPYING
   summary: Port of Xlib XImage and XShmImage functions
+  description: |
+    Port of Xlib XImage and XShmImage functions
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
xcb-util-image 0.4.1

**Destination channel:** defaults

### Links

- [PKG-16175](https://anaconda.atlassian.net/browse/PKG-16175) 
- [Upstream repository](https://gitlab.freedesktop.org/xorg/lib/libxcb-util/-/tree/xcb-util-0.4.1)
- [conda-forge](https://github.com/conda-forge/xcb-util-image-feedstock)

### Explanation of changes:

- new version number

### Tests:

- downstream tests, all succeed - https://package-build.anaconda.com/v1/graph/094b3021-dea0-4d2f-8cde-1ec4aa8409c9


[PKG-16175]: https://anaconda.atlassian.net/browse/PKG-16175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ